### PR TITLE
Use default color for logging in unit tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ function _log(msg, type) {
   }
   if (typeof(console) != 'undefined') {
     var color = {
-      log: '\033[30m',
+      log: '\033[39m',
       warn: '\033[33m',
       error: '\033[31m'
     }


### PR DESCRIPTION
Since I'm having black background in my console, I can't see the test-results any more. Would be better to use `[39m` (default) instead of `[30m` (explicit black)...
