### PR TITLE
Fix warnings on installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "contributors"  : [
     {"name": "Christoph Tavan <dev@tavan.de>", "github": "https://github.com/ctavan"}
   ],
-  "dependencies"  : [],
+  "dependencies"  : {},
   "lib"           : ".",
   "main"          : "./uuid.js",
   "version"       : "1.3.3"


### PR DESCRIPTION
This fixes this warning on installation:

```
npm WARN node-uuid@1.3.3 dependencies field should be hash of <name>:<version-range> pairs
```
