### PR TITLE
Add repository to package.json so we can use `npm docs`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "contributors"  : [
     {"name": "Christoph Tavan <dev@tavan.de>", "github": "https://github.com/ctavan"}
   ],
-  "dependencies"  : {},
   "lib"           : ".",
   "main"          : "./uuid.js",
+  "repository"    : { "type" : "git", "url" : "https://github.com/broofa/node-uuid.git" },
   "version"       : "1.3.3"
 }


### PR DESCRIPTION
- Also remove empty dependencies object that npm copmplains about

npm constantly complains:

```
npm WARN node-uuid@1.3.3 dependencies field should be hash of <name>:<version-range> pairs
```

Also currently we cannot use `npm docs` to get quick access to the readme.
