### PR TITLE
Extracting time from v1 uuid

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -219,12 +219,53 @@
     return buf || unparse(rnds);
   }
 
+  // extracts time (msecs) from v1 type uuid 
+  function v1time(buf, offset) {
+
+    var msec = 0, nsec = 0;
+    var i = buf && offset || 0;
+    var b = buf||[];
+
+    // inspect version at offset 6
+    if ((b[i+6]&0x10)!=0x10) {
+      throw new Error("uuid version 1 expected"); }
+
+    // 'time_low'
+    var tl = 0;
+    tl |= ( b[i++] & 0xff ) << 24;
+    tl |= ( b[i++] & 0xff ) << 16;
+    tl |= ( b[i++] & 0xff ) << 8;
+    tl |=   b[i++] & 0xff ;
+
+      // `time_mid`
+      var tmh = 0;
+      tmh |= ( b[i++] & 0xff ) << 8;
+      tmh |=   b[i++] & 0xff;
+
+      // `time_high_minus_version`
+      tmh |= ( b[i++] & 0xf ) << 24; 
+      tmh |= ( b[i++] & 0xff ) << 16;
+
+      // account for the sign bit
+      msec = 1.0 * ( ( tl >>> 1 ) * 2 + ( ( tl & 0x7fffffff ) % 2 ) ) / 10000.0;
+      msec += 1.0 * ( ( tmh >>> 1 ) * 2 + ( ( tmh & 0x7fffffff ) % 2 ) ) * 0x100000000 / 10000.0;
+      
+      // Per 4.1.4 - Convert from Gregorian epoch to unix epoch
+    msec -= 12219292800000;
+      
+    // getting the nsec. they are not needed now though 
+    // nsec = ( tl & 0xfffffff ) % 10000;
+
+    return msec;
+  }
+
   // Export public API
   var uuid = v4;
   uuid.v1 = v1;
   uuid.v4 = v4;
   uuid.parse = parse;
   uuid.unparse = unparse;
+  uuid.v1time = v1time;
   uuid.BufferClass = BufferClass;
 
   // Export RNG options


### PR DESCRIPTION
Added a method to extract msecs from v1 type uuid. I saw uuidjs had low/high time, but it would be better if everything was in a single, well performing library.
