### PR TITLE
Allow non-global define in AMD detection

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -224,7 +224,7 @@
   uuid.unparse = unparse;
   uuid.BufferClass = BufferClass;
 
-  if (_global.define && define.amd) {
+  if (typeof define === 'function' && define.amd) {
     // Publish as AMD module
     define(function() {return uuid;});
   } else if (typeof(module) != 'undefined' && module.exports) {


### PR DESCRIPTION
[RequireJS](http://requirejs.org/)' r.js builder can be used with [almond](https://github.com/jrburke/almond) to wrap all modules in
an IIFE, with define in the closure rather than on the global object.
This adds support for this case.
