### PR TITLE
Reduce size from 12K minified+gzip to 1K minified+gzip when included via Browserify

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -14,9 +14,9 @@
   // Node.js crypto-based RNG - http://nodejs.org/docs/v0.6.2/api/crypto.html
   //
   // Moderately fast, high quality
-  if (typeof(require) == 'function') {
+  if (typeof(_global.require) == 'function') {
     try {
-      var _rb = require('crypto').randomBytes;
+      var _rb = _global.require('crypto').randomBytes;
       _rng = _rb && function() {return _rb(16);};
     } catch(e) {}
   }
@@ -49,7 +49,7 @@
   }
 
   // Buffer class to use
-  var BufferClass = typeof(Buffer) == 'function' ? Buffer : Array;
+  var BufferClass = typeof(_global.Buffer) == 'function' ? _global.Buffer : Array;
 
   // Maps for number <-> hex string conversion
   var _byteToHex = [];


### PR DESCRIPTION
I'm including node-uuid in http://derbyjs.com/ using Browserify.

Browserify will shim standard Node.js packages including `require('crypto')` and globals including `Buffer`. Since node-uuid already works without these features, including them dramatically bloats the size of the bundle produced by Browserify by about 12X. In addition, I didn't test the performance when included this way, but it is likely worse than the Browser native implementations already in node-uuid.

The pull request simply prevents Browserify from recognizing these items by accessing them from `_global`.
