### PR TITLE
Changed the order of exporting uuid for using browserify app beside requireJS app

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -224,12 +224,12 @@
   uuid.unparse = unparse;
   uuid.BufferClass = BufferClass;
 
-  if (typeof define === 'function' && define.amd) {
+  if (typeof(module) != 'undefined' && module.exports) {
+        // Publish as node.js module
+        module.exports = uuid;
+  } else if (typeof define === 'function' && define.amd) {
     // Publish as AMD module
     define(function() {return uuid;});
-  } else if (typeof(module) != 'undefined' && module.exports) {
-    // Publish as node.js module
-    module.exports = uuid;
   } else {
     // Publish as global (in browsers)
     var _previousRoot = _global.uuid;


### PR DESCRIPTION
Changed the order of exporting uuid by module-type first, because if using browserify to build an app it will conflict with existing apps using requireJS. For requireJS apps it does not matter if it is first tested for existence of module.exports.
