### PR TITLE
Parse Guid method

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -235,6 +235,7 @@
   uuid.v4 = v4;
   uuid.parse = parse;
   uuid.unparse = unparse;
+  uuid.unparseGuid = unparseGuid;
   uuid.BufferClass = BufferClass;
 
   if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Microsoft GUIDs use platform endianness for the data 1 to 3 groups when converting from a byte array.  When trying to convert such IDs coming from a little endian processor (which is every Windows processor, except maybe RT and Embedded), it requires inverting the bytes for the first three groups. I'm not saying it makes a lot of sense in Javascript, but I needed it, so there it is.
