### PR TITLE
Fallback to global for _global

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -4,7 +4,7 @@
 //     MIT License - http://opensource.org/licenses/mit-license.php
 
 (function() {
-  var _global = this;
+  var _global = this || global;
 
   // Unique ID creation requires a high quality random # generator.  We feature
   // detect to determine the best RNG source, normalizing to a function that


### PR DESCRIPTION
In some contexts, "this" may be undefined.
Falling back to global avoids this error.
http://stackoverflow.com/questions/9822561/why-is-this-in-an-anonymous-function-undefined-when-using-strict
