### PR TITLE
Reduce npm payload size by adding .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+test/
+benchmark/
+.nyc_output/
+.npmignore
+bower.json
+component.json


### PR DESCRIPTION
Thanks for creating a module I used every day! I'm trying to give back in whatever little way I can.

The npm payload delivered from `npm install node-uuid` contains a bunch of files which are not needed for the module to actually work. I add an [`.npmignore` file](https://docs.npmjs.com/misc/developers#the-packagejson-file) to exclude all those things from the package payload. Here is the data for your package before and after this change:

| Current | Updated | Savings |
| :-: | :-: | :-: |
| 92 KB | 36 KB | **60.87%** |

_I got these numbers using `du -sh <directory>`_

[According to `node-uuid`'s npmjs.com page](https://www.npmjs.com/package/node-uuid), `node-uuid` has been downloaded 351,945 times in the last day. At 92 KB per download, that is 32.4 GB per day for this module alone! With this change, that number drops by 60.87% to 12.7 GB!

In case you want to double check the resulting package, you can do so locally:

```
# Create a tarball of the resulting package
$ npm pack

# See the file list of that tarball
$ tar -tf node-uuid-<version>.tgz
package/package.json
package/README.md
package/uuid.js
package/LICENSE.md
package/bin/uuid

# Install the tarball as a local node module
$ npm install node-uuid-<version>.tgz
```
