### PR TITLE
Run setupNode when other window.crypto variables are undefined

### DIFF
--- a/uuid.js
+++ b/uuid.js
@@ -14,7 +14,8 @@
 
   function setupBrowser() {
     // Allow for MSIE11 msCrypto
-    var _crypto = _window.crypto || _window.msCrypto;
+    // If the window object doesn't define crypto at all, attempt to use node
+    var _crypto = _window.crypto || _window.msCrypto || setupNode();
 
     if (!_rng && _crypto && _crypto.getRandomValues) {
       // WHATWG crypto-based RNG - http://wiki.whatwg.org/wiki/Crypto


### PR DESCRIPTION
Runs the setupNode function if all other referenced to _window.crypto return undefined. I ran into this issue when running the script in a webWorker in a Jest unit test, but only when using babel to bundle my code. This seems like an easy way to ensure that if a "custom" window object is passed to the IIFE that doesn't include crypto, that the script has a chance to find the node crypto.
