### PR TITLE
(fix) Add .npmignore file to exclude test/ and other non-essentials

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test/
+
+.gitignore
+.travis.yml
+.npmignore


### PR DESCRIPTION
This fixes #181 

Personally, I would go one step further and also remove `HISTORY.md` and `AUTHORS` from the packed module. This is obviously up to the owner. I can adjust the PR to include those should that be desired.