### PR TITLE
Fix use of `global` in browser environment

### DIFF
--- a/lib/rng-browser.js
+++ b/lib/rng-browser.js
@@ -4,7 +4,9 @@
 // feature-detection
 var rng;
 
-var crypto = global.crypto || global.msCrypto; // for IE 11
+var _global = global || window;
+
+var crypto = _global.crypto || _global.msCrypto; // for IE 11
 if (crypto && crypto.getRandomValues) {
   // WHATWG crypto RNG - http://wiki.whatwg.org/wiki/Crypto
   var rnds8 = new Uint8Array(16);


### PR DESCRIPTION
This PR fixes errors that occur in browser environments due to the `global` variable not being present. Still ensures backwards compatibility for node environments or others using global.