### PR TITLE
specify string encoding of UTF8

### DIFF
--- a/lib/sha1.js
+++ b/lib/sha1.js
@@ -3,9 +3,19 @@
 var crypto = require('crypto');
 
 function sha1(bytes) {
-  if (Array.isArray(bytes)) bytes = Buffer.from(bytes);
-  if (typeof bytes === 'string') bytes = Buffer.from(bytes, 'utf8');
-  return crypto.createHash('sha1').update(bytes).digest();
+	// support modern Buffer API
+	if (typeof Buffer.from === 'function') {
+		if (Array.isArray(bytes)) bytes = Buffer.from(bytes);
+		else if (typeof bytes === 'string') bytes = Buffer.from(bytes, 'utf8');
+	}
+
+	// support pre-v4 Buffer API
+	else {
+		if (Array.isArray(bytes)) bytes = new Buffer(bytes);
+		else if (typeof bytes === 'string') bytes = new Buffer(bytes, 'utf8');
+	}
+
+	return crypto.createHash('sha1').update(bytes).digest();
 }
 
 module.exports = sha1;

--- a/lib/sha1.js
+++ b/lib/sha1.js
@@ -4,6 +4,7 @@ var crypto = require('crypto');
 
 function sha1(bytes) {
   if (Array.isArray(bytes)) bytes = Buffer.from(bytes);
+  if (typeof bytes === 'string') bytes = Buffer.from(bytes, 'utf8');
   return crypto.createHash('sha1').update(bytes).digest();
 }
 


### PR DESCRIPTION
Node changed the default from `binary` to `utf8` some time back; this change just specifies `utf8`for older versions of node.

https://nodejs.org/dist/latest-v4.x/docs/api/buffer.html#buffer_class_method_buffer_from_str_encoding
https://nodejs.org/dist/latest-v7.x/docs/api/buffer.html#buffer_class_method_buffer_from_string_encoding