### PR TITLE
Use runmd to build README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-node_modules
-.DS_Store
-
-# VIM temp files
 *.sw*
-
-# Mac desktop services store
 .DS_Store
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -21,23 +21,23 @@ Then generate your uuid version of choice ...
 Version 1 (timestamp):
 
 ```javascript
-var uuidv1 = require('uuid/v1');
-uuidv1(); // ⇨ '59ba7520-5cd9-11e7-9d00-2d24d43111cb'
+const uuidv1 = require('uuid/v1');
+uuidv1(); // ⇨ '75d7e030-5cd9-11e7-9234-2d24d43111cb'
 
 ```
 
 Version 4 (random):
 
 ```javascript
-var uuidv4 = require('uuid/v4');
-uuidv4(); // ⇨ '04faf73f-5a6b-48d4-9481-f03368eb5782'
+const uuidv4 = require('uuid/v4');
+uuidv4(); // ⇨ '7248d964-6ca3-4711-a5fd-92a37c3d937d'
 
 ```
 
 Version 5 (namespace):
 
 ```javascript
-var uuidv5 = require('uuid/v5');
+const uuidv5 = require('uuid/v5');
 
 // ... using predefined DNS namespace (for domain names)
 uuidv5('hello.example.com', uuidv5.DNS); // ⇨ 'fdda765f-fc57-5604-a269-52a7df8164ec'
@@ -49,7 +49,7 @@ uuidv5('http://example.com/hello', uuidv5.URL); // ⇨ '3bbcee75-cecc-5b56-8031-
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
-var MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
+const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
 uuidv5('Hello, World!', MY_NAMESPACE); // ⇨ '630eb68f-e0fa-5ecc-887a-7c7a62614681'
 
 ```
@@ -90,7 +90,7 @@ uuidv5('http://example.com/hello', uuidv5.URL); // -> v5 UUID
 ### Version 1
 
 ```javascript
-var uuidv1 = require('uuid/v1');
+const uuidv1 = require('uuid/v1');
 
 // Incantations
 uuidv1();
@@ -117,13 +117,13 @@ Note: The <node> id is generated guaranteed to stay constant for the lifetime of
 Example: Generate string UUID with fully-specified options
 
 ```javascript
-var options = {
+const v1options = {
   node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
   clockseq: 0x1234,
   msecs: new Date('2011-11-01').getTime(),
   nsecs: 5678
 };
-uuidv1(options); // ⇨ '710b962e-041c-11e1-9234-0123456789ab'
+uuidv1(v1options); // ⇨ '710b962e-041c-11e1-9234-0123456789ab'
 
 ```
 
@@ -131,16 +131,16 @@ Example: In-place generation of two binary IDs
 
 ```javascript
 // Generate two ids in an array
-var arr = new Array();
-uuidv1(null, arr, 0);  // ⇨ [ 89, 187, 56, 112, 92, 217, 17, 231, 146, 52, 45, 36, 212, 49, 17, 203 ]
-uuidv1(null, arr, 16); // ⇨ [ 89, 187, 56, 112, 92, 217, 17, 231, 146, 52, 45, 36, 212, 49, 17, 203, 89, 187, 95, 128, 92, 217, 17, 231, 146, 52, 45, 36, 212, 49, 17, 203 ]
+const arr = new Array();
+uuidv1(null, arr, 0);  // ⇨ [ 117, 216, 124, 112, 92, 217, 17, 231, 146, 52, 45, 36, 212, 49, 17, 203 ]
+uuidv1(null, arr, 16); // ⇨ [ 117, 216, 124, 112, 92, 217, 17, 231, 146, 52, 45, 36, 212, 49, 17, 203, 117, 216, 124, 113, 92, 217, 17, 231, 146, 52, 45, 36, 212, 49, 17, 203 ]
 
 ```
 
 ### Version 4
 
 ```javascript
-var uuidv4 = require('uuid/v4')
+const uuidv4 = require('uuid/v4')
 
 // Incantations
 uuidv4();
@@ -161,29 +161,29 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 Example: Generate string UUID with predefined `random` values
 
 ```javascript
-var options = {
+const v4options = {
   random: [
     0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea,
     0x71, 0xb4, 0xef, 0xe1, 0x67, 0x1c, 0x58, 0x36
   ]
 };
-uuidv4(options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671c5836'
+uuidv4(v4options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671c5836'
 
 ```
 
 Example: Generate two IDs in a single buffer
 
 ```javascript
-var buffer = new Array();
-uuidv4(null, buffer, 0);  // ⇨ [ 164, 236, 231, 188, 89, 93, 72, 254, 155, 94, 242, 166, 0, 235, 25, 45 ]
-uuidv4(null, buffer, 16); // ⇨ [ 164, 236, 231, 188, 89, 93, 72, 254, 155, 94, 242, 166, 0, 235, 25, 45, 73, 3, 95, 92, 114, 19, 73, 11, 175, 168, 47, 42, 74, 193, 128, 164 ]
+const buffer = new Array();
+uuidv4(null, buffer, 0);  // ⇨ [ 152, 79, 119, 75, 197, 171, 69, 69, 149, 136, 228, 229, 58, 89, 81, 91 ]
+uuidv4(null, buffer, 16); // ⇨ [ 152, 79, 119, 75, 197, 171, 69, 69, 149, 136, 228, 229, 58, 89, 81, 91, 113, 87, 4, 31, 72, 124, 64, 206, 132, 220, 2, 49, 27, 161, 127, 88 ]
 
 ```
 
 ### Version 5
 
 ```javascript
-var uuidv5 = require('uuid/v5');
+const uuidv5 = require('uuid/v5');
 
 // Incantations
 uuidv5(name, namespace);
@@ -205,13 +205,13 @@ Example:
 ```javascript
 // Generate a unique namespace (typically you would do this once, outside of
 // your project, then bake this value into your code)
-var uuidv4 = require('uuid/v4');
-var uuidv5 = require('uuid/v5');
-var MY_NAMESPACE = uuidv4();    // ⇨ '424081a2-c02e-4309-a76e-f9a4be3f5f07'
+const uuidv4 = require('uuid/v4');
+const uuidv5 = require('uuid/v5');
+const MY_NAMESPACE = uuidv4();    // ⇨ 'd0a8466a-2c3b-43ce-877f-ed4c6ed4dd92'
 
 // Generate a couple namespace uuids
-uuidv5('hello', MY_NAMESPACE);  // ⇨ '30ef63ad-f6fe-5d95-88ee-d9b1ee21a859'
-uuidv5('world', MY_NAMESPACE);  // ⇨ 'c04edcdf-9f3b-5217-a22d-3ad3d32a0ae0'
+uuidv5('hello', MY_NAMESPACE);  // ⇨ '97d12ec9-1aca-5216-afd4-50338da5b1b2'
+uuidv5('world', MY_NAMESPACE);  // ⇨ 'f81013ca-6799-5191-8643-bcc91cb3ea76'
 
 ```
 
@@ -237,7 +237,7 @@ npm test
 The API below is available for legacy purposes and is not expected to be available post-3.X
 
 ```javascript
-var uuid = require('uuid');
+const uuid = require('uuid');
 
 uuid.v1(...); // alias of uuid/v1
 uuid.v4(...); // alias of uuid/v4

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ Simple, fast generation of [RFC4122](http://www.ietf.org/rfc/rfc4122.txt) UUIDS.
 
 Features:
 
-* Generate RFC4122 version 1, 4 or 5 UUIDs
-* Runs in node.js and browsers
-* Cryptographically strong random number generation on supporting platforms
-* Small footprint  (Want something smaller? [Check this out](https://gist.github.com/982883))
-
-\["Why no version 3?" Per RFC4122, "If backward compatibility is not an issue, SHA-1 is preferred."... I.e. use v5.]
+* Support for version 1, 4 and 5 UUIDs
+* Cross-platform
+* Uses cryptographically-strong random number APIs (when available)
+* Zero-dependency, small footprint (... but not [this small](https://gist.github.com/982883))
 
 ## Quickstart - CommonJS (Recommended)
 
@@ -17,54 +15,81 @@ Features:
 npm install uuid
 ```
 
+Then generate your uuid version of choice ...
+
+Version 1 (timestamp):
+
 ```javascript
-// Generate a v1 UUID (time-based)
-const uuidV1 = require('uuid/v1');
-uuidV1(); // -> '6c84fb90-12c4-11e1-840d-7b25c5ee775a'
-
-
-// Generate a v4 UUID (random)
-const uuidV4 = require('uuid/v4');
-uuidV4(); // -> '110ec58a-a0f2-4ac4-8393-c866d813b8d1'
-
-
-// Generate a v5 UUID (namespace)
-const uuidV5 = require('uuid/v5');
-
-// ... using predefined DNS namespace (for domain names)
-uuidV5('hello.example.com', v5.DNS)); // -> 'fdda765f-fc57-5604-a269-52a7df8164ec'
-
-// ... using predefined URL namespace (for, well, URLs)
-uuidV5('http://example.com/hello', v5.URL); // -> '3bbcee75-cecc-5b56-8031-b6641c1ed1f1'
-
-// ... using a custom namespace
-const MY_NAMESPACE = '(previously generated unique uuid string)';
-uuidV5('hello', MY_NAMESPACE); // -> '90123e1c-7512-523e-bb28-76fab9f2f73d'
+const uuidv1 = require('uuid/v1');
+uuidv1(); // -> '6c84fb90-12c4-11e1-840d-7b25c5ee775a'
 ```
 
-## Quickstart - Pre-packaged for browsers (Not recommended)
+Version 4 (random):
+
+```javascript
+const uuidv4 = require('uuid/v4');
+uuidv4(); // -> '110ec58a-a0f2-4ac4-8393-c866d813b8d1'
+```
+
+Version 5 (namespace):
+
+```javascript
+const uuidv5 = require('uuid/v5');
+
+// ... using predefined DNS namespace (for domain names)
+uuidv5('hello.example.com', uuidv5.DNS)); // -> 'fdda765f-fc57-5604-a269-52a7df8164ec'
+
+// ... using predefined URL namespace (for, well, URLs)
+uuidv5('http://example.com/hello', uuidv5.URL); // -> '3bbcee75-cecc-5b56-8031-b6641c1ed1f1'
+
+// ... using a custom namespace
+const MY_NAMESPACE = '<UUID string you previously generated elsewhere>';
+uuidv5('Hello, World!', MY_NAMESPACE); // -> '90123e1c-7512-523e-bb28-76fab9f2f73d'
+```
+
+## Quickstart - Browser-ready Versions
 
 Browser-ready versions of this module are available via [wzrd.in](https://github.com/jfhbrook/wzrd.in).
 
-```html
-<script src="http://wzrd.in/standalone/uuid@latest"></script>
+For version 1 uuids:
 
+```html
+<script src="http://wzrd.in/standalone/uuid%2Fv1@latest"></script>
 <script>
-uuid.v1(); // -> v1 UUID
-uuid.v4(); // -> v4 UUID
+uuidv1(); // -> v1 UUID
 </script>
 ```
 
-(Note: Do not do this in production.  Just don't.  wzrd.in is a great service, but if you're deploying a "real" service you should be using a packaging tool like browserify or webpack.  If you do go this route you would be well advised to link to a specific version instead of `uuid@latest` to avoid having your code break when we roll out breaking changes.)
+For version 4 uuids:
 
+```html
+<script src="http://wzrd.in/standalone/uuid%2Fv4@latest"></script>
+<script>
+uuidv4(); // -> v4 UUID
+</script>
+```
+
+For version 5 uuids:
+
+```html
+<script src="http://wzrd.in/standalone/uuid%2Fv5@latest"></script>
+<script>
+uuidv5('http://example.com/hello', uuidv5.URL); // -> v5 UUID
+</script>
+```
 
 ## API
 
-### uuid(...)
+### Version 1
 
-Generate a V4 uuid. See uuid.v4 documentation below.
+```javascript
+const uuidv1 = require('uuid/v1');
 
-### uuid.v1([`options` [, `buffer` [, `offset`]]])
+// Allowed arguments
+uuidv1();
+uuidv1(options);
+uuidv1(options, buffer, offset);
+```
 
 Generate and return a RFC4122 v1 (timestamp-based) UUID.
 
@@ -80,14 +105,12 @@ Generate and return a RFC4122 v1 (timestamp-based) UUID.
 
 Returns `buffer`, if specified, otherwise the string form of the UUID
 
-Notes:
-
-1. The randomly generated node id is only guaranteed to stay constant for the lifetime of the current JS runtime. (Future versions of this module may use persistent storage mechanisms to extend this guarantee.)
+Note: The <node> id is generated guaranteed to stay constant for the lifetime of the current JS runtime. (Future versions of this module may use persistent storage mechanisms to extend this guarantee.)
 
 Example: Generate string UUID with fully-specified options
 
 ```javascript
-uuid.v1({
+uuidv1({
   node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
   clockseq: 0x1234,
   msecs: new Date('2011-11-01').getTime(),
@@ -100,19 +123,26 @@ Example: In-place generation of two binary IDs
 ```javascript
 // Generate two ids in an array
 const arr = new Array(32); // -> []
-uuid.v1(null, arr, 0);   // -> [02 a2 ce 90 14 32 11 e1 85 58 0b 48 8e 4f c1 15]
-uuid.v1(null, arr, 16);  // -> [02 a2 ce 90 14 32 11 e1 85 58 0b 48 8e 4f c1 15 02 a3 1c b0 14 32 11 e1 85 58 0b 48 8e 4f c1 15]
+uuidv1(null, arr, 0);   // -> [02 a2 ce 90 14 32 11 e1 85 58 0b 48 8e 4f c1 15]
+uuidv1(null, arr, 16);  // -> [02 a2 ce 90 14 32 11 e1 85 58 0b 48 8e 4f c1 15 02 a3 1c b0 14 32 11 e1 85 58 0b 48 8e 4f c1 15]
 ```
 
-### uuid.v4([`options` [, `buffer` [, `offset`]]])
+### Version 4
+
+```javascript
+const uuidv4 = require('uuid/v4')
+
+// Allowed arguments
+uuidv4();
+uuidv4(options);
+uuidv4(options, buffer, offset);
+```
 
 Generate and return a RFC4122 v4 UUID.
 
 * `options` - (Object) Optional uuid state to apply. Properties may include:
-
   * `random` - (Number[16]) Array of 16 numbers (0-255) to use in place of randomly generated values
-  * `rng` - (Function) Random # generator to use.  Set to one of the built-in generators - `uuid.mathRNG` (all platforms), `uuid.nodeRNG` (node.js only), `uuid.whatwgRNG` (WebKit only) - or a custom function that returns an array[16] of byte values.
-
+  * `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255)
 * `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 * `offset` - (Number) Starting index in `buffer` at which to begin writing.
 
@@ -138,10 +168,58 @@ uuid.v4(null, buffer, 0);
 uuid.v4(null, buffer, 16);
 ```
 
+### Version 5
+
+```javascript
+const uuidv5 = require('uuid/v4');
+
+// Allowed arguments
+uuidv5(name, namespace);
+uuidv5(name, namespace, buffer);
+uuidv5(name, namespace, buffer, offset);
+```
+
+Generate and return a RFC4122 v4 UUID.
+
+* `name` - (String | Array[]) "name" to create UUID with
+* `namespace` - (String | Array[]) "namespace" UUID either as a String or Array[16] of byte values
+* `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
+* `offset` - (Number) Starting index in `buffer` at which to begin writing. Default = 0
+
+Returns `buffer`, if specified, otherwise the string form of the UUID
+
+Example:
+
+```javascript
+// Generate a unique  namespace (typically you would do this once, outside of
+// your project, then bake this value into your code)
+const uuidv4 = require('uuid/v4');
+const MY_NAMESPACE = uuidv4();  //
+
+// Generate a couple namespace uuids
+const uuidv5 = require('uuid/v5');
+uuidv5('hello', MY_NAMESPACE);
+uuidv5('world', MY_NAMESPACE);
+```
+
 ## Testing
 
-```
+```shell
 npm test
+```
+
+## Deprecated / Browser-ready API
+
+The API below is available for legacy purposes and is not expected to be available post-3.X
+
+```javascript
+const uuid = require('uuid');
+
+uuid.v1(...); // alias of uuid/v1
+uuid.v4(...); // alias of uuid/v4
+uuid(...);    // alias of uuid/v4
+
+// uuid.v5() is not supported in this API
 ```
 
 ## Legacy node-uuid package

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Version 1 (timestamp):
 
 ```javascript
 var uuidv1 = require('uuid/v1');
-uuidv1(); // ⇨ '436139d0-5851-11e7-9697-8b2a7a86b8e5'
+uuidv1(); // ⇨ '72164140-5b4d-11e7-9234-f94a466131fa'
 
 ```
 
@@ -30,7 +30,7 @@ Version 4 (random):
 
 ```javascript
 var uuidv4 = require('uuid/v4');
-uuidv4(); // ⇨ 'c47b8d0d-75de-40ad-955f-1adbb740a28a'
+uuidv4(); // ⇨ 'ae6c0c32-5035-43fb-b869-0a758ce1ca5e'
 
 ```
 
@@ -132,8 +132,8 @@ Example: In-place generation of two binary IDs
 ```javascript
 // Generate two ids in an array
 var arr = new Array();
-uuidv1(null, arr, 0);  // ⇨ [ 67, 98, 75, 64, 88, 81, 17, 231, 146, 52, 139, 42, 122, 134, 184, 229 ]
-uuidv1(null, arr, 16); // ⇨ [ 67, 98, 75, 64, 88, 81, 17, 231, 146, 52, 139, 42, 122, 134, 184, 229, 67, 98, 114, 80, 88, 81, 17, 231, 146, 52, 139, 42, 122, 134, 184, 229 ]
+uuidv1(null, arr, 0);  // ⇨ [ 114, 22, 182, 112, 91, 77, 17, 231, 146, 52, 249, 74, 70, 97, 49, 250 ]
+uuidv1(null, arr, 16); // ⇨ [ 114, 22, 182, 112, 91, 77, 17, 231, 146, 52, 249, 74, 70, 97, 49, 250, 114, 22, 182, 113, 91, 77, 17, 231, 146, 52, 249, 74, 70, 97, 49, 250 ]
 
 ```
 
@@ -175,15 +175,15 @@ Example: Generate two IDs in a single buffer
 
 ```javascript
 var buffer = new Array();
-uuidv4(null, buffer, 0);  // ⇨ [ 101, 231, 163, 115, 175, 252, 76, 85, 167, 85, 178, 196, 49, 147, 47, 60 ]
-uuidv4(null, buffer, 16); // ⇨ [ 101, 231, 163, 115, 175, 252, 76, 85, 167, 85, 178, 196, 49, 147, 47, 60, 88, 124, 40, 102, 136, 73, 75, 34, 169, 9, 207, 154, 254, 248, 156, 114 ]
+uuidv4(null, buffer, 0);  // ⇨ [ 0, 80, 12, 81, 66, 195, 73, 102, 183, 155, 166, 7, 156, 8, 2, 48 ]
+uuidv4(null, buffer, 16); // ⇨ [ 0, 80, 12, 81, 66, 195, 73, 102, 183, 155, 166, 7, 156, 8, 2, 48, 232, 224, 39, 13, 154, 18, 68, 157, 166, 88, 93, 106, 73, 171, 223, 89 ]
 
 ```
 
 ### Version 5
 
 ```javascript
-var uuidv5 = require('uuid/v4');
+var uuidv5 = require('uuid/v5');
 
 // Incantations
 uuidv5(name, namespace);
@@ -207,11 +207,11 @@ Example:
 // your project, then bake this value into your code)
 var uuidv4 = require('uuid/v4');
 var uuidv5 = require('uuid/v5');
-var MY_NAMESPACE = uuidv4();    // ⇨ '6e69b7cb-7fe2-40ed-b9db-828666a0564b'
+var MY_NAMESPACE = uuidv4();    // ⇨ '50050e0a-b282-47d0-a1b6-d3d7875c8202'
 
 // Generate a couple namespace uuids
-uuidv5('hello', MY_NAMESPACE);  // ⇨ '2abf921c-443c-5901-b61f-a2c5b634679b'
-uuidv5('world', MY_NAMESPACE);  // ⇨ 'b68243b3-622f-50c6-90a3-c7b52ad5db3a'
+uuidv5('hello', MY_NAMESPACE);  // ⇨ 'cd8eea2d-fcb3-5ff7-acc6-8a68ac9625d1'
+uuidv5('world', MY_NAMESPACE);  // ⇨ 'a0224e2a-273d-5bb5-8f5b-722638d10595'
 
 ```
 

--- a/README_js.md
+++ b/README_js.md
@@ -179,7 +179,7 @@ uuidv4(null, buffer, 16); // RESULT
 ### Version 5
 
 ```javascript
-var uuidv5 = require('uuid/v4');
+var uuidv5 = require('uuid/v5');
 
 // Incantations
 uuidv5(name, namespace);

--- a/README_js.md
+++ b/README_js.md
@@ -1,3 +1,6 @@
+```javascript --hide
+runmd.onRequire = path => path.replace(/^uuid/, './');
+```
 
 # uuid [![Build Status](https://secure.travis-ci.org/kelektiv/node-uuid.svg?branch=master)](http://travis-ci.org/kelektiv/node-uuid) #
 
@@ -20,38 +23,35 @@ Then generate your uuid version of choice ...
 
 Version 1 (timestamp):
 
-```javascript
+```javascript --context
 var uuidv1 = require('uuid/v1');
-uuidv1(); // ⇨ '436139d0-5851-11e7-9697-8b2a7a86b8e5'
-
+uuidv1(); // RESULT
 ```
 
 Version 4 (random):
 
-```javascript
+```javascript --context
 var uuidv4 = require('uuid/v4');
-uuidv4(); // ⇨ 'c47b8d0d-75de-40ad-955f-1adbb740a28a'
-
+uuidv4(); // RESULT
 ```
 
 Version 5 (namespace):
 
-```javascript
+```javascript --context
 var uuidv5 = require('uuid/v5');
 
 // ... using predefined DNS namespace (for domain names)
-uuidv5('hello.example.com', uuidv5.DNS); // ⇨ 'fdda765f-fc57-5604-a269-52a7df8164ec'
+uuidv5('hello.example.com', uuidv5.DNS); // RESULT
 
 // ... using predefined URL namespace (for, well, URLs)
-uuidv5('http://example.com/hello', uuidv5.URL); // ⇨ '3bbcee75-cecc-5b56-8031-b6641c1ed1f1'
+uuidv5('http://example.com/hello', uuidv5.URL); // RESULT
 
 // ... using a custom namespace
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
 var MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
-uuidv5('Hello, World!', MY_NAMESPACE); // ⇨ '630eb68f-e0fa-5ecc-887a-7c7a62614681'
-
+uuidv5('Hello, World!', MY_NAMESPACE); // RESULT
 ```
 
 ## Quickstart - Browser-ready Versions
@@ -116,25 +116,23 @@ Note: The <node> id is generated guaranteed to stay constant for the lifetime of
 
 Example: Generate string UUID with fully-specified options
 
-```javascript
+```javascript --context
 var options = {
   node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
   clockseq: 0x1234,
   msecs: new Date('2011-11-01').getTime(),
   nsecs: 5678
 };
-uuidv1(options); // ⇨ '710b962e-041c-11e1-9234-0123456789ab'
-
+uuidv1(options); // RESULT
 ```
 
 Example: In-place generation of two binary IDs
 
-```javascript
+```javascript --context
 // Generate two ids in an array
 var arr = new Array();
-uuidv1(null, arr, 0);  // ⇨ [ 67, 98, 75, 64, 88, 81, 17, 231, 146, 52, 139, 42, 122, 134, 184, 229 ]
-uuidv1(null, arr, 16); // ⇨ [ 67, 98, 75, 64, 88, 81, 17, 231, 146, 52, 139, 42, 122, 134, 184, 229, 67, 98, 114, 80, 88, 81, 17, 231, 146, 52, 139, 42, 122, 134, 184, 229 ]
-
+uuidv1(null, arr, 0);  // RESULT
+uuidv1(null, arr, 16); // RESULT
 ```
 
 ### Version 4
@@ -160,24 +158,22 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 
 Example: Generate string UUID with predefined `random` values
 
-```javascript
+```javascript --context
 var options = {
   random: [
     0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea,
     0x71, 0xb4, 0xef, 0xe1, 0x67, 0x1c, 0x58, 0x36
   ]
 };
-uuidv4(options); // ⇨ '109156be-c4fb-41ea-b1b4-efe1671c5836'
-
+uuidv4(options); // RESULT
 ```
 
 Example: Generate two IDs in a single buffer
 
-```javascript
+```javascript --context
 var buffer = new Array();
-uuidv4(null, buffer, 0);  // ⇨ [ 101, 231, 163, 115, 175, 252, 76, 85, 167, 85, 178, 196, 49, 147, 47, 60 ]
-uuidv4(null, buffer, 16); // ⇨ [ 101, 231, 163, 115, 175, 252, 76, 85, 167, 85, 178, 196, 49, 147, 47, 60, 88, 124, 40, 102, 136, 73, 75, 34, 169, 9, 207, 154, 254, 248, 156, 114 ]
-
+uuidv4(null, buffer, 0);  // RESULT
+uuidv4(null, buffer, 16); // RESULT
 ```
 
 ### Version 5
@@ -202,17 +198,16 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 
 Example:
 
-```javascript
+```javascript --run
 // Generate a unique namespace (typically you would do this once, outside of
 // your project, then bake this value into your code)
 var uuidv4 = require('uuid/v4');
 var uuidv5 = require('uuid/v5');
-var MY_NAMESPACE = uuidv4();    // ⇨ '6e69b7cb-7fe2-40ed-b9db-828666a0564b'
+var MY_NAMESPACE = uuidv4();    // RESULT
 
 // Generate a couple namespace uuids
-uuidv5('hello', MY_NAMESPACE);  // ⇨ '2abf921c-443c-5901-b61f-a2c5b634679b'
-uuidv5('world', MY_NAMESPACE);  // ⇨ 'b68243b3-622f-50c6-90a3-c7b52ad5db3a'
-
+uuidv5('hello', MY_NAMESPACE);  // RESULT
+uuidv5('world', MY_NAMESPACE);  // RESULT
 ```
 
 ## Command Line
@@ -249,6 +244,3 @@ uuid(...);    // alias of uuid/v4
 ## Legacy node-uuid package
 
 The code for the legacy node-uuid package is available in the `node-uuid` branch.
-
-----
-Markdown generated from [README_js.md](README_js.md) by [![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)

--- a/README_js.md
+++ b/README_js.md
@@ -24,21 +24,21 @@ Then generate your uuid version of choice ...
 Version 1 (timestamp):
 
 ```javascript --context
-var uuidv1 = require('uuid/v1');
+const uuidv1 = require('uuid/v1');
 uuidv1(); // RESULT
 ```
 
 Version 4 (random):
 
 ```javascript --context
-var uuidv4 = require('uuid/v4');
+const uuidv4 = require('uuid/v4');
 uuidv4(); // RESULT
 ```
 
 Version 5 (namespace):
 
 ```javascript --context
-var uuidv5 = require('uuid/v5');
+const uuidv5 = require('uuid/v5');
 
 // ... using predefined DNS namespace (for domain names)
 uuidv5('hello.example.com', uuidv5.DNS); // RESULT
@@ -50,7 +50,7 @@ uuidv5('http://example.com/hello', uuidv5.URL); // RESULT
 //
 // Note: Custom namespaces should be a UUID string specific to your application!
 // E.g. the one here was generated using this modules `uuid` CLI.
-var MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
+const MY_NAMESPACE = '1b671a64-40d5-491e-99b0-da01ff1f3341';
 uuidv5('Hello, World!', MY_NAMESPACE); // RESULT
 ```
 
@@ -90,7 +90,7 @@ uuidv5('http://example.com/hello', uuidv5.URL); // -> v5 UUID
 ### Version 1
 
 ```javascript
-var uuidv1 = require('uuid/v1');
+const uuidv1 = require('uuid/v1');
 
 // Incantations
 uuidv1();
@@ -117,20 +117,20 @@ Note: The <node> id is generated guaranteed to stay constant for the lifetime of
 Example: Generate string UUID with fully-specified options
 
 ```javascript --context
-var options = {
+const v1options = {
   node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],
   clockseq: 0x1234,
   msecs: new Date('2011-11-01').getTime(),
   nsecs: 5678
 };
-uuidv1(options); // RESULT
+uuidv1(v1options); // RESULT
 ```
 
 Example: In-place generation of two binary IDs
 
 ```javascript --context
 // Generate two ids in an array
-var arr = new Array();
+const arr = new Array();
 uuidv1(null, arr, 0);  // RESULT
 uuidv1(null, arr, 16); // RESULT
 ```
@@ -138,7 +138,7 @@ uuidv1(null, arr, 16); // RESULT
 ### Version 4
 
 ```javascript
-var uuidv4 = require('uuid/v4')
+const uuidv4 = require('uuid/v4')
 
 // Incantations
 uuidv4();
@@ -159,19 +159,19 @@ Returns `buffer`, if specified, otherwise the string form of the UUID
 Example: Generate string UUID with predefined `random` values
 
 ```javascript --context
-var options = {
+const v4options = {
   random: [
     0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea,
     0x71, 0xb4, 0xef, 0xe1, 0x67, 0x1c, 0x58, 0x36
   ]
 };
-uuidv4(options); // RESULT
+uuidv4(v4options); // RESULT
 ```
 
 Example: Generate two IDs in a single buffer
 
 ```javascript --context
-var buffer = new Array();
+const buffer = new Array();
 uuidv4(null, buffer, 0);  // RESULT
 uuidv4(null, buffer, 16); // RESULT
 ```
@@ -179,7 +179,7 @@ uuidv4(null, buffer, 16); // RESULT
 ### Version 5
 
 ```javascript
-var uuidv5 = require('uuid/v5');
+const uuidv5 = require('uuid/v5');
 
 // Incantations
 uuidv5(name, namespace);
@@ -201,9 +201,9 @@ Example:
 ```javascript --run
 // Generate a unique namespace (typically you would do this once, outside of
 // your project, then bake this value into your code)
-var uuidv4 = require('uuid/v4');
-var uuidv5 = require('uuid/v5');
-var MY_NAMESPACE = uuidv4();    // RESULT
+const uuidv4 = require('uuid/v4');
+const uuidv5 = require('uuid/v5');
+const MY_NAMESPACE = uuidv4();    // RESULT
 
 // Generate a couple namespace uuids
 uuidv5('hello', MY_NAMESPACE);  // RESULT
@@ -232,7 +232,7 @@ npm test
 The API below is available for legacy purposes and is not expected to be available post-3.X
 
 ```javascript
-var uuid = require('uuid');
+const uuid = require('uuid');
 
 uuid.v1(...); // alias of uuid/v1
 uuid.v4(...); // alias of uuid/v4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uuid",
-  "version": "3.0.1",
-  "description": "RFC4122 (v1 and v4) generator",
+  "version": "3.1.0",
+  "description": "RFC4122 (v1, v4, and v5) UUIDs",
   "keywords": [
     "uuid",
     "guid",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
     "uuid": "./bin/uuid"
   },
   "devDependencies": {
-    "mocha": "3.1.2"
+    "mocha": "3.1.2",
+    "runmd": "0.1.7"
   },
   "scripts": {
-    "test": "mocha test/test.js"
+    "test": "mocha test/test.js",
+    "md": "runmd --watch --output=README.md README_js.md",
+    "prepare": "runmd --output=README.md README_js.md"
   },
   "browser": {
     "./lib/rng.js": "./lib/rng-browser.js",
@@ -24,5 +27,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/kelektiv/node-uuid.git"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
https://github.com/broofa/runmd is a new module I've been working on that allows you to evaluate JS code blocks in README (and other markdown) files.  Benefits of this:

1. Hooking it into the publish process (via `npm`  'prepare' script hook)  acts as a unit test of sorts.  Publish doesn't happen if the README file can't be built, so there's incentive to insure the README file is kept current.
2. It can automatically inject expression results into the markdown, which makes including expected output in docs easier
3. It forces authors to write code that is accurate and runnable instead of copy/pasting/guessing (**cough** not that I've ever done that.)

Thoughts?