### PR TITLE
v5 additions (default namespaces, buffer inputs, cli binary args)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Version 1 (timestamp):
 
 ```javascript
 const uuidv1 = require('uuid/v1');
-uuidv1(); // ⇨ '985123a0-7e4f-11e7-9022-fb7190c856e4'
+uuidv1(); // ⇨ 'aee02740-8590-11e7-b662-938de05596cd'
 
 ```
 
@@ -30,7 +30,7 @@ Version 4 (random):
 
 ```javascript
 const uuidv4 = require('uuid/v4');
-uuidv4(); // ⇨ 'df7cca36-3d7a-40f4-8f06-ae03cc22f045'
+uuidv4(); // ⇨ 'f576bd76-e5eb-4924-981b-631f245cbac4'
 
 ```
 
@@ -132,8 +132,39 @@ Example: In-place generation of two binary IDs
 ```javascript
 // Generate two ids in an array
 const arr = new Array();
-uuidv1(null, arr, 0);  // ⇨ [ 152, 81, 152, 208, 126, 79, 17, 231, 146, 52, 251, 113, 144, 200, 86, 228 ]
-uuidv1(null, arr, 16); // ⇨ [ 152, 81, 152, 208, 126, 79, 17, 231, 146, 52, 251, 113, 144, 200, 86, 228, 152, 81, 191, 224, 126, 79, 17, 231, 146, 52, 251, 113, 144, 200, 86, 228 ]
+uuidv1(null, arr, 0);  // ⇨ [ 174, 224, 156, 112, 133, 144, 17, 231, 146, 52, 147, 141, 224, 85, 150, 205 ]
+uuidv1(null, arr, 16); // ⇨ [ 174,
+                       //   224,
+                       //   156,
+                       //   112,
+                       //   133,
+                       //   144,
+                       //   17,
+                       //   231,
+                       //   146,
+                       //   52,
+                       //   147,
+                       //   141,
+                       //   224,
+                       //   85,
+                       //   150,
+                       //   205,
+                       //   174,
+                       //   224,
+                       //   195,
+                       //   128,
+                       //   133,
+                       //   144,
+                       //   17,
+                       //   231,
+                       //   146,
+                       //   52,
+                       //   147,
+                       //   141,
+                       //   224,
+                       //   85,
+                       //   150,
+                       //   205 ]
 
 ```
 
@@ -175,8 +206,8 @@ Example: Generate two IDs in a single buffer
 
 ```javascript
 const buffer = new Array();
-uuidv4(null, buffer, 0);  // ⇨ [ 217, 119, 223, 141, 202, 93, 66, 3, 178, 198, 149, 37, 232, 4, 107, 241 ]
-uuidv4(null, buffer, 16); // ⇨ [ 217, 119, 223, 141, 202, 93, 66, 3, 178, 198, 149, 37, 232, 4, 107, 241, 218, 189, 231, 45, 208, 56, 70, 125, 142, 27, 46, 27, 183, 9, 8, 202 ]
+uuidv4(null, buffer, 0);  // ⇨ [ 10, 57, 90, 158, 68, 193, 78, 41, 181, 25, 148, 121, 147, 180, 7, 20 ]
+uuidv4(null, buffer, 16); // ⇨ [ 10, 57, 90, 158, 68, 193, 78, 41, 181, 25, 148, 121, 147, 180, 7, 20, 220, 3, 73, 232, 236, 6, 70, 167, 157, 80, 17, 75, 66, 163, 4, 152 ]
 
 ```
 
@@ -193,8 +224,10 @@ uuidv5(name, namespace, buffer, offset);
 
 Generate and return a RFC4122 v5 UUID.
 
-* `name` - (String | Array[]) "name" to create UUID with
+* `name` - (String | Array[] | Buffer) "name" to create UUID with
 * `namespace` - (String | Array[]) "namespace" UUID either as a String or Array[16] of byte values
+
+    There are four namespaces as defined in RFC4122 that are conveniently accessible (as properties of the required `uuid/v5` object): `DNS`, `URL`, `OID` (ISO OID), `X500` (X.500 DN)
 * `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 * `offset` - (Number) Starting index in `buffer` at which to begin writing. Default = 0
 
@@ -207,11 +240,11 @@ Example:
 // your project, then bake this value into your code)
 const uuidv4 = require('uuid/v4');
 const uuidv5 = require('uuid/v5');
-const MY_NAMESPACE = uuidv4();    // ⇨ '8dc079dd-0313-4563-864f-008eb45bf87f'
+const MY_NAMESPACE = uuidv4();    // ⇨ 'a632737c-1257-4116-b5bc-89d3225d1e3d'
 
 // Generate a couple namespace uuids
-uuidv5('hello', MY_NAMESPACE);  // ⇨ 'c506b68b-ed29-5662-bb90-7f43e624e333'
-uuidv5('world', MY_NAMESPACE);  // ⇨ '669a6357-2584-534e-84bb-ac69f1c8ef44'
+uuidv5('hello', MY_NAMESPACE);  // ⇨ '56e37db9-e36e-598f-a3c5-5183ca5d418a'
+uuidv5('world', MY_NAMESPACE);  // ⇨ 'e2fc4cf7-506f-5dae-b1a0-0b583feced5b'
 
 ```
 
@@ -220,8 +253,27 @@ uuidv5('world', MY_NAMESPACE);  // ⇨ '669a6357-2584-534e-84bb-ac69f1c8ef44'
 UUIDs can be generated from the command line with the `uuid` command.
 
 ```shell
+$ uuid --help
+Usage:
+  uuid
+  uuid v1
+  uuid v4
+  uuid v5 [--encoding=<encoding>] <name> <namespace uuid>
+      <encoding> Specifies the encoding of <name>, valid values (in node v8): ascii, utf8, utf16le, ucs2, base64, latin1, binary, hex
+      <namespace uuid> Must either be a valid UUID or a shortcut for the 4 predefined UUIDs according to RFC4122: URL, DNS, OID, X500
+  uuid --help
+
 $ uuid
 ddeb27fb-d9a0-4624-be4d-4615062daed4
+
+$ uuid v4
+79f5832a-6f40-4c77-945d-3968bef36133
+
+$ uuid v5 --encoding=hex 68656c6c6f OID
+4d71d03f-f19b-5d9e-8523-9628ba18063c
+
+$ uuid v5 hello OID
+4d71d03f-f19b-5d9e-8523-9628ba18063c
 ```
 
 Type `uuid --help` for usage details

--- a/README_js.md
+++ b/README_js.md
@@ -189,8 +189,10 @@ uuidv5(name, namespace, buffer, offset);
 
 Generate and return a RFC4122 v5 UUID.
 
-* `name` - (String | Array[]) "name" to create UUID with
+* `name` - (String | Array[] | Buffer) "name" to create UUID with
 * `namespace` - (String | Array[]) "namespace" UUID either as a String or Array[16] of byte values
+
+    There are four namespaces as defined in RFC4122 that are conveniently accessible (as properties of the required `uuid/v5` object): `DNS`, `URL`, `OID` (ISO OID), `X500` (X.500 DN)
 * `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 * `offset` - (Number) Starting index in `buffer` at which to begin writing. Default = 0
 
@@ -215,8 +217,27 @@ uuidv5('world', MY_NAMESPACE);  // RESULT
 UUIDs can be generated from the command line with the `uuid` command.
 
 ```shell
+$ uuid --help
+Usage:
+  uuid
+  uuid v1
+  uuid v4
+  uuid v5 [--encoding=<encoding>] <name> <namespace uuid>
+      <encoding> Specifies the encoding of <name>, valid values (in node v8): ascii, utf8, utf16le, ucs2, base64, latin1, binary, hex
+      <namespace uuid> Must either be a valid UUID or a shortcut for the 4 predefined UUIDs according to RFC4122: URL, DNS, OID, X500
+  uuid --help
+
 $ uuid
 ddeb27fb-d9a0-4624-be4d-4615062daed4
+
+$ uuid v4
+79f5832a-6f40-4c77-945d-3968bef36133
+
+$ uuid v5 --encoding=hex 68656c6c6f OID
+4d71d03f-f19b-5d9e-8523-9628ba18063c
+
+$ uuid v5 hello OID
+4d71d03f-f19b-5d9e-8523-9628ba18063c
 ```
 
 Type `uuid --help` for usage details

--- a/bin/uuid
+++ b/bin/uuid
@@ -6,9 +6,10 @@ function usage() {
   console.log('  uuid');
   console.log('  uuid v1');
   console.log('  uuid v4');
-  console.log('  uuid v5 [--hex] <name> <namespace uuid>');
+  console.log('  uuid v5 [--encoding=<encoding>] <name> <namespace uuid>');
+  console.log('      <encoding> Specifies the encoding of <name>, valid values (in node v8): ascii, utf8, utf16le, ucs2, base64, latin1, binary, hex');
+  console.log('      <namespace uuid> Must either be a valid UUID or a shortcut for the 4 predefined UUIDs according to RFC4122: URL, DNS, OID, X500');
   console.log('  uuid --help');
-  console.log('\nNote: <namespace uuid> may be "URL" or "DNS" to use the corresponding UUIDs defined by RFC4122');
 }
 
 var args = process.argv.slice(2);
@@ -34,8 +35,10 @@ switch (version) {
     var uuidV5 = require('../v5');
 
     var name = args.shift();
-    if (name === '--hex'){
-        name = Buffer.from(args.shift(), 'hex');
+    if (args.length == 2 && /^--encoding=([a-z0-9]+)$/.test(name)){
+      var newBuffer = (typeof Buffer.from === 'function' ? function(val,format){ return Buffer.from(val,format); } : function(val,format){ return new Buffer(val,format); });
+      var format = name.match(/^--encoding=([a-z0-9]+)$/)[1];
+      name = newBuffer(args.shift(), format);
     }
     var namespace = args.shift();
     assert(name != null, 'v5 name not specified');

--- a/bin/uuid
+++ b/bin/uuid
@@ -33,7 +33,6 @@ switch (version) {
   case 'v5':
     var uuidV5 = require('../v5');
 
-    var isHex = false;
     var name = args.shift();
     if (name === '--hex'){
         name = Buffer.from(args.shift(), 'hex');

--- a/bin/uuid
+++ b/bin/uuid
@@ -6,7 +6,7 @@ function usage() {
   console.log('  uuid');
   console.log('  uuid v1');
   console.log('  uuid v4');
-  console.log('  uuid v5 <name> <namespace uuid>');
+  console.log('  uuid v5 [--hex] <name> <namespace uuid>');
   console.log('  uuid --help');
   console.log('\nNote: <namespace uuid> may be "URL" or "DNS" to use the corresponding UUIDs defined by RFC4122');
 }
@@ -33,7 +33,11 @@ switch (version) {
   case 'v5':
     var uuidV5 = require('../v5');
 
+    var isHex = false;
     var name = args.shift();
+    if (name === '--hex'){
+        name = Buffer.from(args.shift(), 'hex');
+    }
     var namespace = args.shift();
     assert(name != null, 'v5 name not specified');
     assert(namespace != null, 'v5 namespace not specified');

--- a/bin/uuid
+++ b/bin/uuid
@@ -40,6 +40,8 @@ switch (version) {
 
     if (namespace == 'URL') namespace = uuidV5.URL;
     if (namespace == 'DNS') namespace = uuidV5.DNS;
+    if (namespace == 'OID') namespace = uuidV5.OID;
+    if (namespace == 'X500') namespace = uuidV5.X500;
 
     console.log(uuidV5(name, namespace));
     break;

--- a/test/test.js
+++ b/test/test.js
@@ -76,7 +76,9 @@ test('v5', function() {
   // Test different input formats
   assert.equal(v5('hello', v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
   assert.equal(v5([0x68, 0x65, 0x6c, 0x6c, 0x6f], v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
-  assert.equal(v5(Buffer.from('68656c6c6f','hex'), v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
+
+  var newBuffer = (typeof Buffer.from === 'function' ? function(val,format){ return Buffer.from(val,format); } : function(val,format){ return new Buffer(val,format); });
+  assert.equal(v5(newBuffer('68656c6c6f','hex'), v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
 
 
   // test the buffer functionality

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,8 @@ test('v5', function() {
   assert.equal(v5('hello.example.com', v5.DNS), 'fdda765f-fc57-5604-a269-52a7df8164ec');
   assert.equal(v5('http://example.com/hello', v5.URL), '3bbcee75-cecc-5b56-8031-b6641c1ed1f1');
   assert.equal(v5('hello', '0f5abcd1-c194-47f3-905b-2df7263a084b'), '90123e1c-7512-523e-bb28-76fab9f2f73d');
+  assert.equal(v5('hello', v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
+  assert.equal(v5('hello', v5.X500), 'feddb5c6-6b33-5dd7-a4d8-fb98254f583f');
 
   // test the buffer functionality
   var buf = new Array(16);

--- a/test/test.js
+++ b/test/test.js
@@ -73,6 +73,12 @@ test('v5', function() {
   assert.equal(v5('hello', v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
   assert.equal(v5('hello', v5.X500), 'feddb5c6-6b33-5dd7-a4d8-fb98254f583f');
 
+  // Test different input formats
+  assert.equal(v5('hello', v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
+  assert.equal(v5([0x68, 0x65, 0x6c, 0x6c, 0x6f], v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
+  assert.equal(v5(Buffer.from('68656c6c6f','hex'), v5.OID), '4d71d03f-f19b-5d9e-8523-9628ba18063c');
+
+
   // test the buffer functionality
   var buf = new Array(16);
   var testBuf = [0xfd, 0xda, 0x76, 0x5f, 0xfc, 0x57, 0x56, 0x04, 0xa2, 0x69, 0x52, 0xa7, 0xdf, 0x81, 0x64, 0xec];

--- a/v5.js
+++ b/v5.js
@@ -46,5 +46,7 @@ function v5(name, namespace, buf, offset) {
 // Pre-defined namespaces, per Appendix C
 v5.DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
 v5.URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+v5.OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
+v5.X500 = '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
 
 module.exports = v5;

--- a/v5.js
+++ b/v5.js
@@ -20,10 +20,19 @@ function stringToBytes(str) {
   return bytes;
 }
 
+function bufferToBytes(buf) {
+  var bytes = new Array(buf.length);
+  for (var i = 0; i < buf.length; i++) {
+    bytes[i] = buf.readUInt8(i);
+  }
+  return bytes;
+}
+
 function v5(name, namespace, buf, offset) {
   var off = buf && offset || 0;
   
-  if (typeof(name) == 'string') name = stringToBytes(name);
+  if (typeof(Buffer) !== 'undefined' && typeof(name) == 'object' && name instanceof Buffer) name = bufferToBytes(name); // begin by testing for the Buffer type because browsers will not necessarily have it defined
+  else if (typeof(name) == 'string') name = stringToBytes(name);
   if (typeof(namespace) == 'string') namespace = uuidToBytes(namespace);
 
   if (!Array.isArray(name)) throw TypeError('name must be an array of bytes');

--- a/v5.js
+++ b/v5.js
@@ -1,6 +1,8 @@
 var sha1 = require('./lib/sha1-browser');
 var bytesToUuid = require('./lib/bytesToUuid');
 
+var bufferIsSupported = (Object.prototype.toString.call(Buffer) === '[object Function]');
+
 function uuidToBytes(uuid) {
   // Note: We assume we're being passed a valid uuid string
   var bytes = [];
@@ -31,7 +33,7 @@ function bufferToBytes(buf) {
 function v5(name, namespace, buf, offset) {
   var off = buf && offset || 0;
   
-  if (typeof(Buffer) !== 'undefined' && typeof(name) == 'object' && name instanceof Buffer) name = bufferToBytes(name); // begin by testing for the Buffer type because browsers will not necessarily have it defined
+  if (bufferIsSupported && typeof(name) == 'object' && name instanceof Buffer) name = bufferToBytes(name);
   else if (typeof(name) == 'string') name = stringToBytes(name);
   if (typeof(namespace) == 'string') namespace = uuidToBytes(namespace);
 


### PR DESCRIPTION
Hi, many thanks for the library. Here my changes:

1. Added the Object ID and X500 default namespaces as they are also defined in rfc4122, appendix c. There is a total of 4 namespaces listed, but only two were defined in the library - so why not add the other two?
2. uuid/v5 now also takes a (nodejs) `Buffer` object as input and converts it into an array as needed assuming the bytes to be unsigned chars
3. for the cli I added the option `--hex` (before the `name` argument) as to indicate that the name argument is actually a hexadecimal string that is to be read as binary data


Regarding 2: For systems/browsers not supporting a Buffer-object/class I put a safeguard, but I'm not 100% sure wether this works - maybe someone who knows better can confirm?
