### PR TITLE
Export v3 and v5 from main package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 var v1 = require('./v1');
+var v3 = require('./v3');
 var v4 = require('./v4');
+var v5 = require('./v5');
 
 var uuid = v4;
 uuid.v1 = v1;
+uuid.v3 = v3;
 uuid.v4 = v4;
+uuid.v5 = v5;
 
 module.exports = uuid;


### PR DESCRIPTION
On the server or when using es6 imports with tree shaking, it's idiomatic to use:

```es6
import { v4, v5 } from 'uuid';
```

instead of:

```es6
import v4 from 'uuid';
import v5 from 'uuid/v5';
```

This makes the former possible.