### PR TITLE
why would one be failing and not the other?

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -258,3 +258,17 @@ test('ids spanning 1ms boundary are 100ns apart', function() {
   var dt = parseInt(after, 16) - parseInt(before, 16);
   assert(dt === 1, 'Ids spanning 1ms boundary are 100ns apart');
 });
+
+test('generated sequentially', function() {
+  var a = [null, null];
+  var list = a.map(uuid.v1);
+  assert(list.indexOf(1) === -1);
+});
+
+test('generated sequentially with a wrapper', function() {
+  var a = [null, null];
+  var list = a.map(function() {
+    return uuid.v1();
+  });
+  assert(list.indexOf(1) === -1);
+});


### PR DESCRIPTION
Confused as to why uuids are not generated when `uuid.v1()` or `uuid.v4()` is called from `Array.map()`.

failing & passing tests provided to isolate

```
node --version
v8.9.1
```