### PR TITLE
Adds the Nil UUID as a constant to the module exports.

### DIFF
--- a/lib/v35.js
+++ b/lib/v35.js
@@ -48,6 +48,7 @@ module.exports = function(name, version, hashfunc) {
   // Pre-defined namespaces, per Appendix C
   generateUUID.DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
   generateUUID.URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+  generateUUID.NIL = '00000000-0000-0000-0000-000000000000';
 
   return generateUUID;
 };

--- a/v1.js
+++ b/v1.js
@@ -106,4 +106,6 @@ function v1(options, buf, offset) {
   return buf ? buf : bytesToUuid(b);
 }
 
+v1.NIL = '00000000-0000-0000-0000-000000000000';
+
 module.exports = v1;

--- a/v4.js
+++ b/v4.js
@@ -26,4 +26,6 @@ function v4(options, buf, offset) {
   return buf || bytesToUuid(rnds);
 }
 
+v4.NIL = '00000000-0000-0000-0000-000000000000';
+
 module.exports = v4;


### PR DESCRIPTION
This seems kinda trivial, but I had an occasion a few weeks ago where I needed the [NIL UUID value](https://tools.ietf.org/html/rfc4122#section-4.1.7) obviously this is easy enough to just define as a constant.  But I thought that it would have been included as part of this package and was surprised not to find it as it's part of the UUID specification.  However when I went to add it to node-uuid I initially thought to add it in the same way that the v5 includes the DNS and URL namespaces.  However the NIL uuid is categorically different and should really be included with all versions 1, 3, 4 & 5.
I considered centralizing the definition but the overhead of a require just for a static constant seemed a bit much.
If this implementation is alright, I'd like to update the docs with this PR.

Please let me know what you think.