### PR TITLE
Remove Date as an available type for msecs option of v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Generate and return a RFC4122 v1 (timestamp-based) UUID.
 
   * `node` - (Array) Node id as Array of 6 bytes (per 4.1.6). Default: Randomly generated ID.  See note 1.
   * `clockseq` - (Number between 0 - 0x3fff) RFC clock sequence.  Default: An internally maintained clockseq is used.
-  * `msecs` - (Number | Date) Time in milliseconds since unix Epoch.  Default: The current time is used.
+  * `msecs` - (Number) Time in milliseconds since unix Epoch.  Default: The current time is used.
   * `nsecs` - (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if `msecs` is unspecified. Default: internal uuid counter is used, as per 4.2.1.2.
 
 * `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.

--- a/README_js.md
+++ b/README_js.md
@@ -132,7 +132,7 @@ Generate and return a RFC4122 v1 (timestamp-based) UUID.
 
   * `node` - (Array) Node id as Array of 6 bytes (per 4.1.6). Default: Randomly generated ID.  See note 1.
   * `clockseq` - (Number between 0 - 0x3fff) RFC clock sequence.  Default: An internally maintained clockseq is used.
-  * `msecs` - (Number | Date) Time in milliseconds since unix Epoch.  Default: The current time is used.
+  * `msecs` - (Number) Time in milliseconds since unix Epoch.  Default: The current time is used.
   * `nsecs` - (Number between 0-9999) additional time, in 100-nanosecond units. Ignored if `msecs` is unspecified. Default: internal uuid counter is used, as per 4.2.1.2.
 
 * `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.


### PR DESCRIPTION
Fixes #248 

I figured this was the simplest approach and the most self-documenting considering that the option is named `msecs`.



