### PR TITLE
Fix illegal invocation of getRandomValues

### DIFF
--- a/lib/rng-browser.js
+++ b/lib/rng-browser.js
@@ -3,8 +3,9 @@
 // and inconsistent support for the `crypto` API.  We do the best we can via
 // feature-detection
 
-var getRandomValues = (typeof(crypto) != 'undefined' && crypto.getRandomValues) ||
-                      (typeof(msCrypto) != 'undefined' && msCrypto.getRandomValues);
+// getRandomValues needs to be invoked in a context where "this" is a Crypto implementation.
+var getRandomValues = (typeof(crypto) != 'undefined' && crypto.getRandomValues.bind(crypto)) ||
+                      (typeof(msCrypto) != 'undefined' && msCrypto.getRandomValues.bind(msCrypto));
 if (getRandomValues) {
   // WHATWG crypto RNG - http://wiki.whatwg.org/wiki/Crypto
   var rnds8 = new Uint8Array(16); // eslint-disable-line no-undef


### PR DESCRIPTION
getRandomValues needs to be invoked in a context where "this" is a Crypto implementation. Binding the function to its respective Crypto implementation fixes the illegal invocation.

Fixes #256