### PR TITLE
fix assignment to readonly property to allow running in strict mode

### DIFF
--- a/lib/v35.js
+++ b/lib/v35.js
@@ -43,7 +43,7 @@ module.exports = function(name, version, hashfunc) {
     return buf || bytesToUuid(bytes);
   };
 
-  generateUUID.name = name;
+  Object.defineProperty(generateUUID, 'name', {value: name});
 
   // Pre-defined namespaces, per Appendix C
   generateUUID.DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';

--- a/lib/v35.js
+++ b/lib/v35.js
@@ -43,7 +43,11 @@ module.exports = function(name, version, hashfunc) {
     return buf || bytesToUuid(bytes);
   };
 
-  Object.defineProperty(generateUUID, 'name', {value: name});
+
+  // only attempt to set the name if's configurable (which it should be on node > 0.12)
+  if (Object.getOwnPropertyDescriptor(generateUUID, 'name').configurable) {
+    Object.defineProperty(generateUUID, 'name', {value: name});
+  }
 
   // Pre-defined namespaces, per Appendix C
   generateUUID.DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';

--- a/lib/v35.js
+++ b/lib/v35.js
@@ -43,7 +43,6 @@ module.exports = function(name, version, hashfunc) {
     return buf || bytesToUuid(bytes);
   };
 
-
   // only attempt to set the name if's configurable (which it should be on node > 0.12)
   if (Object.getOwnPropertyDescriptor(generateUUID, 'name').configurable) {
     Object.defineProperty(generateUUID, 'name', {value: name});


### PR DESCRIPTION
Replaced assignment to readonly Function.name with Object.defineProperty, as you can't assign to readonly properties in strict mode.

Fixes #268 