### PR TITLE
Added ability to use rng-browser in v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Generate and return a RFC4122 v4 UUID.
 
 * `options` - (Object) Optional uuid state to apply. Properties may include:
   * `random` - (Number[16]) Array of 16 numbers (0-255) to use in place of randomly generated values
-  * `rng` - (Function) Random # generator function that returns an Array[16] of byte values (0-255)
+  * `rng` - (Function | 'rng-browser') Random # generator function that returns an Array[16] of byte values (0-255) or the string 'rng-browser' to use this library's random # generator function for the browser
 * `buffer` - (Array | Buffer) Array or buffer where UUID bytes are to be written.
 * `offset` - (Number) Starting index in `buffer` at which to begin writing.
 

--- a/v4.js
+++ b/v4.js
@@ -10,6 +10,10 @@ function v4(options, buf, offset) {
   }
   options = options || {};
 
+  if (options.rng === 'rng-browser') {
+    options.rng = require('./lib/rng-browser');
+  }
+
   var rnds = options.random || (options.rng || rng)();
 
   // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`


### PR DESCRIPTION
When trying to use `uuid/v4` in the browser, I couldn't find any information on how to do so. The `lib/rng-browser.js` file is present but there's no way to specify using this through options as the `rng` option in v4 only takes in a Function as input.

I've added the ability for the `rng` option to also take the string "rng-browser" as input. This will use the `lib/rng-browser.js` file and won't require users to manually require this specific file and pass it as an option. It's only a very small change but I hope it'll save people time in the future.

```
var uuid = require('uuid/v4');
let options = {
  rng: 'rng-browser'
}
let uuidNum = uuid(options);
```

I've updated the README to reflect these changes.

I've also noticed that there are md5-browser.js and sha1-browser.js files as well. I'm happy to open pull requests for these in order to make it easier for users to specify using these files (if you think there is a need for it). 