### PR TITLE
Get correct version of IE11 crypto

### DIFF
--- a/lib/rng-browser.js
+++ b/lib/rng-browser.js
@@ -3,9 +3,11 @@
 // and inconsistent support for the `crypto` API.  We do the best we can via
 // feature-detection
 
-// getRandomValues needs to be invoked in a context where "this" is a Crypto implementation.
-var getRandomValues = (typeof(crypto) != 'undefined' && crypto.getRandomValues.bind(crypto)) ||
-                      (typeof(msCrypto) != 'undefined' && msCrypto.getRandomValues.bind(msCrypto));
+// getRandomValues needs to be invoked in a context where "this" is a Crypto
+// implementation. Also, find the complete implementation of crypto on IE11.
+var getRandomValues = (typeof(crypto) != 'undefined' && crypto.getRandomValues && crypto.getRandomValues.bind(crypto)) ||
+                      (typeof(msCrypto) != 'undefined' && typeof window.msCrypto.getRandomValues == 'function' && msCrypto.getRandomValues.bind(msCrypto));
+
 if (getRandomValues) {
   // WHATWG crypto RNG - http://wiki.whatwg.org/wiki/Crypto
   var rnds8 = new Uint8Array(16); // eslint-disable-line no-undef


### PR DESCRIPTION
Users on Windows 7 and IE11 sometimes trigger a bind error because the crypto object exists but getRandomValues is undefined. Using https://github.com/openpgpjs/openpgpjs/pull/207 as a reference, I've added a more robust check for the necessary crypto properties in IE 11.

We deployed our branch into production yesterday. I'll report back in a week to let everyone know if this fixed the issue or not, and if so we can potentially merge?