### PR TITLE
fix: add TypeScript defaults support

### DIFF
--- a/v1.js
+++ b/v1.js
@@ -107,3 +107,4 @@ function v1(options, buf, offset) {
 }
 
 module.exports = v1;
+module.exports.default = v1;

--- a/v3.js
+++ b/v3.js
@@ -2,3 +2,4 @@ var v35 = require('./lib/v35.js');
 var md5 = require('./lib/md5');
 
 module.exports = v35('v3', 0x30, md5);
+module.exports.default = module.exports;

--- a/v4.js
+++ b/v4.js
@@ -27,3 +27,4 @@ function v4(options, buf, offset) {
 }
 
 module.exports = v4;
+module.exports.default = v4;

--- a/v5.js
+++ b/v5.js
@@ -1,3 +1,4 @@
 var v35 = require('./lib/v35.js');
 var sha1 = require('./lib/sha1');
 module.exports = v35('v5', 0x50, sha1);
+module.exports.default = module.exports;


### PR DESCRIPTION
This PR adds a simple `module.exports.default` line to each of the version files.  When the following `tsconfig.json` values are used:

```json
    "module": "commonjs",
    "target": "es6"
```

And `esModuleInterop` is `false`, TypeScript will compile the uuid-consuming file with the assumption that `module.exports.defaults` exists. One might argue that this change is not needed, but `esModuleInterop` can really screw things up when using the compilation result in certain bundlers. Several other widely used CJS modules have also added this tiny bit of compatibility with no ill-effect.