### PR TITLE
Add missing namespaces to v35.js

### DIFF
--- a/lib/v35.js
+++ b/lib/v35.js
@@ -52,6 +52,8 @@ module.exports = function(name, version, hashfunc) {
   // Pre-defined namespaces, per Appendix C
   generateUUID.DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
   generateUUID.URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+  generateUUID.OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
+  generateUUID.X500 = '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
 
   return generateUUID;
 };


### PR DESCRIPTION
Add missing predefined namespaces for OID and X500 from the RFC 4122 spec to v35.js
See https://tools.ietf.org/html/rfc4122#appendix-C