### PR TITLE
Add namespace OID and X500

### DIFF
--- a/lib/v35.js
+++ b/lib/v35.js
@@ -52,6 +52,8 @@ module.exports = function(name, version, hashfunc) {
   // Pre-defined namespaces, per Appendix C
   generateUUID.DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
   generateUUID.URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+  generateUUID.OID = '6ba7b812-9dad-11d1-80b4-00c04fd430c8';
+  generateUUID.X500 = '6ba7b814-9dad-11d1-80b4-00c04fd430c8';
 
   return generateUUID;
 };


### PR DESCRIPTION
Adds namespace OID and X500 according to [RFC4122](https://www.ietf.org/rfc/rfc4122.txt)
```
   /* Name string is an ISO OID */
   uuid_t NameSpace_OID = { /* 6ba7b812-9dad-11d1-80b4-00c04fd430c8 */
       0x6ba7b812,
       0x9dad,
       0x11d1,
       0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8
   };
```
```
   /* Name string is an X.500 DN (in DER or a text output format) */
   uuid_t NameSpace_X500 = { /* 6ba7b814-9dad-11d1-80b4-00c04fd430c8 */
       0x6ba7b814,
       0x9dad,
       0x11d1,
       0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8
   };
```