### PR TITLE
fix: improve v4() performance

### DIFF
--- a/src/v4.ts
+++ b/src/v4.ts
@@ -51,9 +51,8 @@ function v4<TBuf extends Uint8Array = Uint8Array>(
     return native.randomUUID();
   }
 
-  // Putting tail-code here in a separate function (as opposed to inline in this
-  // function) allows for compiler optimizations in the common case where
-  // we never get this far (i.e. when native.randomUUID() is called, above).
+  // Putting tail-code that could just go inline here in a separate function
+  // allows for compiler optimizations that dramatically improve performance.
   //
   // REF: https://github.com/uuidjs/uuid/issues/892
   return _v4(options, buf, offset);


### PR DESCRIPTION
Moving tail-code in v4() to a separate function appears to enable some interesting compiler optimizations.  `v4()` gets a 3X boost in Node.  In Chrome, there's a small (7% or so) boost, but not enough to be noteworthy.

@pnappa, can you pull this branch and comment here with your results for `npm run test:benchmark`?

Fixes #892

> [!NOTE]
> node@18, 20, 22, and 24 all show similar results with this change

### Benchmarks
node@24 before:
```
uuid.v4() using crypto.randomUUID x 7,342,641 ops/sec ±0.27% (101 runs sampled)
uuid.v4() w/out crypto.randomUUID x 3,301,438 ops/sec ±0.25% (98 runs sampled)
crypto.randomUUID() x 17,718,991 ops/sec ±0.62% (95 runs sampled)
```

node@24 after:
```
uuid.v4() using crypto.randomUUID x 22,060,386 ops/sec ±0.60% (94 runs sampled)
uuid.v4() w/out crypto.randomUUID x 7,832,501 ops/sec ±0.35% (96 runs sampled)
crypto.randomUUID() x 17,428,071 ops/sec ±0.57% (97 runs sampled)
```

Chrome@138 before:
```
uuid.v4() using crypto.randomUUID x 647,225 ops/sec ±7.95% (57 runs sampled)
benchmark.js:84 uuid.v4() w/out crypto.randomUUID x 952,060 ops/sec ±0.59% (67 runs sampled)
benchmark.js:84 crypto.randomUUID() x 620,774 ops/sec ±5.69% (58 runs sampled)
```

Chrome@138 after:
```
benchmark.js:84 uuid.v4() using crypto.randomUUID x 699,045 ops/sec ±3.02% (49 runs sampled)
benchmark.js:84 uuid.v4() w/out crypto.randomUUID x 966,959 ops/sec ±1.68% (68 runs sampled)
benchmark.js:84 crypto.randomUUID() x 638,242 ops/sec ±3.49% (58 runs sampled)
```