### PR TITLE
chore: set up npm trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 name: release-please
@@ -32,7 +33,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
 
@@ -43,6 +44,4 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.UUID_NPM_RELEASE_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Enabling NPM trusted publishing per https://docs.npmjs.com/trusted-publishers#github-actions-configuration. 

I've updated npmjs.com settings for this package as follows:

<img width="500" alt="CleanShot 2025-09-28 at 08 46 18" src="https://github.com/user-attachments/assets/22714418-4d07-458a-86b1-81ae71345458" />

Hopefully this will "just work", but it it doesn't we can sort it out the next time we publish. 

Closes #908 
