### PR TITLE
fix: improve performance

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -5,34 +5,42 @@ function parse(uuid: string) {
     throw TypeError('Invalid UUID');
   }
 
+  const result = new Uint8Array(16);
   let v;
-  return Uint8Array.of(
-    (v = parseInt(uuid.slice(0, 8), 16)) >>> 24,
-    (v >>> 16) & 0xff,
-    (v >>> 8) & 0xff,
-    v & 0xff,
 
-    // Parse ........-####-....-....-............
-    (v = parseInt(uuid.slice(9, 13), 16)) >>> 8,
-    v & 0xff,
+  // Parse ########-....-....-....-............
+  v = parseInt(uuid.slice(0, 8), 16);
+  result[0] = v >>> 24;
+  result[1] = (v >>> 16) & 0xff;
+  result[2] = (v >>> 8) & 0xff;
+  result[3] = v & 0xff;
 
-    // Parse ........-....-####-....-............
-    (v = parseInt(uuid.slice(14, 18), 16)) >>> 8,
-    v & 0xff,
+  // Parse ........-####-....-....-............
+  v = parseInt(uuid.slice(9, 13), 16);
+  result[4] = v >>> 8;
+  result[5] = v & 0xff;
 
-    // Parse ........-....-....-####-............
-    (v = parseInt(uuid.slice(19, 23), 16)) >>> 8,
-    v & 0xff,
+  // Parse ........-....-####-....-............
+  v = parseInt(uuid.slice(14, 18), 16);
+  result[6] = v >>> 8;
+  result[7] = v & 0xff;
 
-    // Parse ........-....-....-....-############
-    // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
-    ((v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000) & 0xff,
-    (v / 0x100000000) & 0xff,
-    (v >>> 24) & 0xff,
-    (v >>> 16) & 0xff,
-    (v >>> 8) & 0xff,
-    v & 0xff
-  );
+  // Parse ........-....-....-####-............
+  v = parseInt(uuid.slice(19, 23), 16);
+  result[8] = v >>> 8;
+  result[9] = v & 0xff;
+
+  // Parse ........-....-....-....-############
+  // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+  v = parseInt(uuid.slice(24, 36), 16);
+  result[10] = (v / 0x10000000000) & 0xff;
+  result[11] = (v / 0x100000000) & 0xff;
+  result[12] = (v >>> 24) & 0xff;
+  result[13] = (v >>> 16) & 0xff;
+  result[14] = (v >>> 8) & 0xff;
+  result[15] = v & 0xff;
+
+  return result;
 }
 
 export default parse;

--- a/src/sha1-browser.ts
+++ b/src/sha1-browser.ts
@@ -82,29 +82,30 @@ function sha1(bytes: Uint8Array): Uint8Array {
     H[4] = (H[4] + e) >>> 0;
   }
 
-  // Note: Uint8Array.of() does `& 0xff` for each value
-  return Uint8Array.of(
-    H[0] >> 24,
-    H[0] >> 16,
-    H[0] >> 8,
-    H[0],
-    H[1] >> 24,
-    H[1] >> 16,
-    H[1] >> 8,
-    H[1],
-    H[2] >> 24,
-    H[2] >> 16,
-    H[2] >> 8,
-    H[2],
-    H[3] >> 24,
-    H[3] >> 16,
-    H[3] >> 8,
-    H[3],
-    H[4] >> 24,
-    H[4] >> 16,
-    H[4] >> 8,
-    H[4]
-  );
+  // Note: Uint8Array assignment automatically masks values to 8-bit range
+  const result = new Uint8Array(20);
+  result[0] = H[0] >> 24;
+  result[1] = H[0] >> 16;
+  result[2] = H[0] >> 8;
+  result[3] = H[0];
+  result[4] = H[1] >> 24;
+  result[5] = H[1] >> 16;
+  result[6] = H[1] >> 8;
+  result[7] = H[1];
+  result[8] = H[2] >> 24;
+  result[9] = H[2] >> 16;
+  result[10] = H[2] >> 8;
+  result[11] = H[2];
+  result[12] = H[3] >> 24;
+  result[13] = H[3] >> 16;
+  result[14] = H[3] >> 8;
+  result[15] = H[3];
+  result[16] = H[4] >> 24;
+  result[17] = H[4] >> 16;
+  result[18] = H[4] >> 8;
+  result[19] = H[4];
+
+  return result;
 }
 
 export default sha1;

--- a/src/v1ToV6.ts
+++ b/src/v1ToV6.ts
@@ -21,25 +21,27 @@ export default function v1ToV6(uuid: string | Uint8Array): UUIDTypes {
 
 // Do the field transformation needed for v1 -> v6
 function _v1ToV6(v1Bytes: Uint8Array) {
-  return Uint8Array.of(
-    ((v1Bytes[6] & 0x0f) << 4) | ((v1Bytes[7] >> 4) & 0x0f),
-    ((v1Bytes[7] & 0x0f) << 4) | ((v1Bytes[4] & 0xf0) >> 4),
-    ((v1Bytes[4] & 0x0f) << 4) | ((v1Bytes[5] & 0xf0) >> 4),
-    ((v1Bytes[5] & 0x0f) << 4) | ((v1Bytes[0] & 0xf0) >> 4),
+  const result = new Uint8Array(16);
 
-    ((v1Bytes[0] & 0x0f) << 4) | ((v1Bytes[1] & 0xf0) >> 4),
-    ((v1Bytes[1] & 0x0f) << 4) | ((v1Bytes[2] & 0xf0) >> 4),
+  result[0] = ((v1Bytes[6] & 0x0f) << 4) | ((v1Bytes[7] >> 4) & 0x0f);
+  result[1] = ((v1Bytes[7] & 0x0f) << 4) | ((v1Bytes[4] & 0xf0) >> 4);
+  result[2] = ((v1Bytes[4] & 0x0f) << 4) | ((v1Bytes[5] & 0xf0) >> 4);
+  result[3] = ((v1Bytes[5] & 0x0f) << 4) | ((v1Bytes[0] & 0xf0) >> 4);
 
-    0x60 | (v1Bytes[2] & 0x0f),
-    v1Bytes[3],
+  result[4] = ((v1Bytes[0] & 0x0f) << 4) | ((v1Bytes[1] & 0xf0) >> 4);
+  result[5] = ((v1Bytes[1] & 0x0f) << 4) | ((v1Bytes[2] & 0xf0) >> 4);
 
-    v1Bytes[8],
-    v1Bytes[9],
-    v1Bytes[10],
-    v1Bytes[11],
-    v1Bytes[12],
-    v1Bytes[13],
-    v1Bytes[14],
-    v1Bytes[15]
-  );
+  result[6] = 0x60 | (v1Bytes[2] & 0x0f);
+  result[7] = v1Bytes[3];
+
+  result[8] = v1Bytes[8];
+  result[9] = v1Bytes[9];
+  result[10] = v1Bytes[10];
+  result[11] = v1Bytes[11];
+  result[12] = v1Bytes[12];
+  result[13] = v1Bytes[13];
+  result[14] = v1Bytes[14];
+  result[15] = v1Bytes[15];
+
+  return result;
 }

--- a/src/v6ToV1.ts
+++ b/src/v6ToV1.ts
@@ -21,25 +21,27 @@ export default function v6ToV1(uuid: UUIDTypes): UUIDTypes {
 
 // Do the field transformation needed for v6 -> v1
 function _v6ToV1(v6Bytes: Uint8Array) {
-  return Uint8Array.of(
-    ((v6Bytes[3] & 0x0f) << 4) | ((v6Bytes[4] >> 4) & 0x0f),
-    ((v6Bytes[4] & 0x0f) << 4) | ((v6Bytes[5] & 0xf0) >> 4),
-    ((v6Bytes[5] & 0x0f) << 4) | (v6Bytes[6] & 0x0f),
-    v6Bytes[7],
+  const result = new Uint8Array(16);
 
-    ((v6Bytes[1] & 0x0f) << 4) | ((v6Bytes[2] & 0xf0) >> 4),
-    ((v6Bytes[2] & 0x0f) << 4) | ((v6Bytes[3] & 0xf0) >> 4),
+  result[0] = ((v6Bytes[3] & 0x0f) << 4) | ((v6Bytes[4] >> 4) & 0x0f);
+  result[1] = ((v6Bytes[4] & 0x0f) << 4) | ((v6Bytes[5] & 0xf0) >> 4);
+  result[2] = ((v6Bytes[5] & 0x0f) << 4) | (v6Bytes[6] & 0x0f);
+  result[3] = v6Bytes[7];
 
-    0x10 | ((v6Bytes[0] & 0xf0) >> 4),
-    ((v6Bytes[0] & 0x0f) << 4) | ((v6Bytes[1] & 0xf0) >> 4),
+  result[4] = ((v6Bytes[1] & 0x0f) << 4) | ((v6Bytes[2] & 0xf0) >> 4);
+  result[5] = ((v6Bytes[2] & 0x0f) << 4) | ((v6Bytes[3] & 0xf0) >> 4);
 
-    v6Bytes[8],
-    v6Bytes[9],
-    v6Bytes[10],
-    v6Bytes[11],
-    v6Bytes[12],
-    v6Bytes[13],
-    v6Bytes[14],
-    v6Bytes[15]
-  );
+  result[6] = 0x10 | ((v6Bytes[0] & 0xf0) >> 4);
+  result[7] = ((v6Bytes[0] & 0x0f) << 4) | ((v6Bytes[1] & 0xf0) >> 4);
+
+  result[8] = v6Bytes[8];
+  result[9] = v6Bytes[9];
+  result[10] = v6Bytes[10];
+  result[11] = v6Bytes[11];
+  result[12] = v6Bytes[12];
+  result[13] = v6Bytes[13];
+  result[14] = v6Bytes[14];
+  result[15] = v6Bytes[15];
+
+  return result;
 }


### PR DESCRIPTION
Changes usage of replaces variadic Uint8Array.of with direct assignments. 


i ran benchmarks a few times (node v22, M1 processor) in main vs this implementation, results (average):
  | Function | Main Branch | Perf Branch | Improvement |
  |----------|-------------|-------------|-------------|
  | parse()  | 3,203,087   | 4,049,873   | +26.4%      |
  | v6()     | 1,915,662   | 2,426,219   | +26.6%      |
  | v1ToV6() | 2,008,340   | 2,735,990   | +36.2%      |
  | v6ToV1() | 1,979,843   | 2,614,741   | +32.1%      |
