### PR TITLE
fix: support older node resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "uuid": "./dist-node/bin/uuid"
   },
   "sideEffects": false,
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "node": "./dist-node/index.js",
       "default": "./dist/index.js"
     },


### PR DESCRIPTION
This PR does a small but important backwards support update to `package.json` for some common node-resolvers in 3rd party utilities such as `eslint`

* `eslint-plugin-import` uses a custom node-resolver that doesn't support `"exports"` correctly, but falls back to `"main"`
  * see this issue: https://github.com/import-js/eslint-plugin-import/issues/2703#issuecomment-1421307722
* `typescript` looks at `"export[].types"` first and falls back to root `"types"` in package.json, but I recall that there was a bug in an older version of typescript where it wasn't
  * I need to find the source-of-truth for this, and I don't have time to dig for that. Regardless, having `"types"` like this defined in `"exports"` is the correct way as per Node docs: https://nodejs.org/api/packages.html#community-conditions-definitions
  
  
My understanding is that the default node/deno/bun resolvers, as well as for bundlers such as webpack, vite, rollup, etc, all know to prioritize `"exports"` and should never fallback to `"main"` ever, so setting `"main"` the same as `"default"` should be of no concern. Adding `"main"` back in is just for backwards support of older resolvers that don't yet meet current standards