### PR TITLE
fix: add types condition to node export for moduleResolution bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run docs:diff
+      - run: npx -y publint --strict
 
   test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "node": "./dist-node/index.js",
+      "node": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist-node/index.js"
+      },
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
## Problem

`uuid@14.0.0` defines `exports["."].node` as a plain string pointing to `./dist-node/index.js`, but omits a `types` field for that condition. `publint` warns that TypeScript consumers using `moduleResolution: "bundler"` cannot resolve types when importing via the `node` export condition.

**Reproduction:**
```shell
npm pack uuid@14.0.0 --silent >/dev/null
npx publint@0.3.21 run uuid-14.0.0.tgz --level warning
```

Actual output:
```
pkg.exports["."].node types is not exported. Consider adding pkg.exports["."].node.types: "./dist/index.d.ts"
to be compatible with TypeScript's "moduleResolution": "bundler" compiler option.
```

## Fix

Expand the `node` condition from a plain string to an object with an explicit `types` field:

```diff
-"node": "./dist-node/index.js",
+"node": {
+  "types": "./dist/index.d.ts",
+  "default": "./dist-node/index.js"
+},
```

## Verification

After patching, packing, and running publint on the tarball:
```
Running publint v0.3.21 for uuid-14.0.0.tgz...
All good!
```

No runtime behaviour is changed — the fix only adds metadata for TypeScript tooling.