### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ For the creation of [RFC9562](https://www.rfc-editor.org/rfc/rfc9562.html) (form
 
 ```shell
 npm install uuid
+# or
+deno install uuid
 ```
 
 **2. Create a UUID**


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The README shows `npm install uuid`. Since Deno is a drop-in replacement for npm these days, this adds a Deno line alongside it:

```sh
deno install uuid
```

Docs-only change (uuid resolves and installs the same way under Deno). Totally fine to close this if you'd rather keep it npm-only. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
